### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mangelv/ce0cb5c8-e6a4-4c6f-b1a4-22dab98da5cb/9c391b5e-4880-4d6e-b658-93ae8bef2c2c/_apis/work/boardbadge/274e2ed0-65aa-46fa-9c4a-f6d4cbc287a3)](https://dev.azure.com/mangelv/ce0cb5c8-e6a4-4c6f-b1a4-22dab98da5cb/_boards/board/t/9c391b5e-4880-4d6e-b658-93ae8bef2c2c/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mangelv/ce0cb5c8-e6a4-4c6f-b1a4-22dab98da5cb/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.